### PR TITLE
fix: Use modrinth maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
         url 'https://masa.dy.fi/maven'
     }
     maven {
-        url 'https://maven.terraformersmc.com/releases'
+        url 'https://api.modrinth.com/maven'
     }
     maven { url "https://maven.shedaniel.me/" }
     maven {
@@ -39,7 +39,7 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "fi.dy.masa.malilib:malilib-fabric-${project.minecraft_version}:${project.malilib_version}"
-    modImplementation "com.terraformersmc:modmenu:${project.mod_menu_version}"
+    modImplementation "maven.modrinth:modmenu:${project.mod_menu_version}"
 
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.


### PR DESCRIPTION
The modrinth maven is much better than the terraformers maven, which has been officially announced by terraformersmc as "unstable at this time".

The three recommended alternative mavens by terraformers are the [modrinth](https://api.modrinth.com/maven) repo, which is what I chose here, the [KotlinDiscord mirror](https://maven.kotlindiscord.com/repository/terraformers/), and the [terraformersmc discord archive](https://raw.githubusercontent.com/TerraformersMC/Archive/main/releases/).